### PR TITLE
minor index.html change to add direction map link

### DIFF
--- a/index.html
+++ b/index.html
@@ -339,7 +339,7 @@
                 // Pokemon not hidden
                 console.log("Adding marker " + p.name);
 
-                var detail_str = "<b>"+p.name+"</b><br>Time left: " + formatSeconds(p.timeleft) + "<br>Lat: "+p.lat+"<br>Long: "+p.lng;
+                var detail_str = "<b>"+p.name+"</b><br>Time left: " + formatSeconds(p.timeleft) + "<br>Lat: "+p.lat+"<br>Long: "+p.lng+"<br><a href='https://www.google.com/maps/dir/Current+Location/"+p.lat+","+p.lng+"' target='_blank' title='Go Catch \'Em'>Go Catch \'Em!</a></div>";
 
                 if (markers.hasOwnProperty(pokehash)) {
                   markers[pokehash].details = detail_str;


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [X ] New feature

The following changes were made

- google map url to "Go Catch 'Em" in marker's info window (like in current AHAAAAAAA's version)
-
-

If this is related to an existing ticket, include a link to it as well.


Added a google maps url to link to the directions to the selected pokemon.

Works best on mobile if the marker's click event is changed to setContent/open and the mouseover/outs are removed,
may add a config to choose this format or initial?