### PR TITLE
title attrib fix for the directions link

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -337,7 +337,7 @@
                 // Pokemon not hidden
                 console.log("Adding marker " + p.name);
 
-                var detail_str = "<b>"+p.name+"</b><br>Time left: " + formatSeconds(p.timeleft) + "<br>Lat: "+p.lat+"<br>Long: "+p.lng+"<br><a href='https://www.google.com/maps/dir/Current+Location/"+p.lat+","+p.lng+"' target='_blank' title='Go Catch \'Em'>Go Catch \'Em!</a></div>";
+                var detail_str = "<b>"+p.name+"</b><br>Time left: " + formatSeconds(p.timeleft) + "<br>Lat: "+p.lat+"<br>Long: "+p.lng+"<br><a href='https://www.google.com/maps/dir/Current+Location/"+p.lat+","+p.lng+"' target='_blank' title=\"Go Catch \'Em!\">Go Catch \'Em!</a></div>";
 
                 if (markers.hasOwnProperty(pokehash)) {
                   markers[pokehash].details = detail_str;


### PR DESCRIPTION
This pull request includes a

- [x ] Bug fix
- [ ] New feature

The following changes were made

-switch the title attrib in the anchor to "'s instead of 's so the title does not truncate.
-
-

If this is related to an existing ticket, include a link to it as well.

switch the title attrib in the anchor to "'s instead of 's as the 'em truncates the title to "Go Catch " instead of "Go Catch 'Em" 

 ie title='Go Catch 'Em' of course doesn't work but title="Go Catch 'Em" does.